### PR TITLE
add enhanced Thing interface

### DIFF
--- a/g.go
+++ b/g.go
@@ -4,3 +4,6 @@ package generics
 
 // G is an interface under which all possible types apply
 type G interface{}
+
+// Thing is a helpful enhancement to this amazing interface.
+type Thing G

--- a/g_test.go
+++ b/g_test.go
@@ -17,9 +17,27 @@ func TestBool(t *testing.T) {
 	}
 }
 
+func TestBoolThing(t *testing.T) {
+	var original bool
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
 func BenchmarkBool(b *testing.B) {
 	var result G
 	f := func(g G) G { return g }
+	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
+	for i := 0; i < b.N; i++ {
+		result = f(true)
+	}
+	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
+}
+
+func BenchmarkBoolThing(b *testing.B) {
+	var result G
+	f := func(g Thing) Thing { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(true)
@@ -46,6 +64,25 @@ func BenchmarkInt(b *testing.B) {
 	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
 }
 
+func TestIntThing(t *testing.T) {
+	var original int
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func BenchmarkIntThing(b *testing.B) {
+	var result Thing
+	var t int = 1
+	f := func(g Thing) Thing { return g }
+	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
+	for i := 0; i < b.N; i++ {
+		result = f(t)
+	}
+	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
+}
+
 func TestInt8(t *testing.T) {
 	var original int8
 	result := func(g G) G { return g }(original)
@@ -58,6 +95,25 @@ func BenchmarkInt8(b *testing.B) {
 	var result G
 	var t int8 = 1
 	f := func(g G) G { return g }
+	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
+	for i := 0; i < b.N; i++ {
+		result = f(t)
+	}
+	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
+}
+
+func TestInt8Thing(t *testing.T) {
+	var original int8
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func BenchmarkInt8Thing(b *testing.B) {
+	var result Thing
+	var t int8 = 1
+	f := func(g Thing) Thing { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -84,6 +140,25 @@ func BenchmarkInt16(b *testing.B) {
 	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
 }
 
+func TestInt16Thing(t *testing.T) {
+	var original int16
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func BenchmarkInt16Thing(b *testing.B) {
+	var result Thing
+	var t int16 = 1
+	f := func(g Thing) Thing { return g }
+	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
+	for i := 0; i < b.N; i++ {
+		result = f(t)
+	}
+	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
+}
+
 func TestInt32(t *testing.T) {
 	var original int32
 	result := func(g G) G { return g }(original)
@@ -96,6 +171,25 @@ func BenchmarkInt32(b *testing.B) {
 	var result G
 	var t int32 = 1
 	f := func(g G) G { return g }
+	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
+	for i := 0; i < b.N; i++ {
+		result = f(t)
+	}
+	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
+}
+
+func TestInt32Thing(t *testing.T) {
+	var original int32
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func BenchmarkInt32Thing(b *testing.B) {
+	var result Thing
+	var t int32 = 1
+	f := func(g Thing) Thing { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -122,6 +216,25 @@ func BenchmarkInt64(b *testing.B) {
 	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
 }
 
+func TestInt64Thing(t *testing.T) {
+	var original int64
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func BenchmarkInt64Thing(b *testing.B) {
+	var result Thing
+	var t int64 = 1
+	f := func(g Thing) Thing { return g }
+	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
+	for i := 0; i < b.N; i++ {
+		result = f(t)
+	}
+	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
+}
+
 func TestUInt(t *testing.T) {
 	var original uint
 	result := func(g G) G { return g }(original)
@@ -134,6 +247,25 @@ func BenchmarkUInt(b *testing.B) {
 	var result G
 	var t uint = 1
 	f := func(g G) G { return g }
+	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
+	for i := 0; i < b.N; i++ {
+		result = f(t)
+	}
+	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
+}
+
+func TestUIntThing(t *testing.T) {
+	var original uint
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func BenchmarkUIntThing(b *testing.B) {
+	var result Thing
+	var t uint = 1
+	f := func(g Thing) Thing { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -160,6 +292,25 @@ func BenchmarkUInt8(b *testing.B) {
 	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
 }
 
+func TestUInt8Thing(t *testing.T) {
+	var original uint8
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func BenchmarkUInt8Thing(b *testing.B) {
+	var result Thing
+	var t uint8 = 1
+	f := func(g Thing) Thing { return g }
+	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
+	for i := 0; i < b.N; i++ {
+		result = f(t)
+	}
+	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
+}
+
 func TestUInt16(t *testing.T) {
 	var original uint16
 	result := func(g G) G { return g }(original)
@@ -172,6 +323,25 @@ func BenchmarkUInt16(b *testing.B) {
 	var result G
 	var t uint16 = 1
 	f := func(g G) G { return g }
+	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
+	for i := 0; i < b.N; i++ {
+		result = f(t)
+	}
+	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
+}
+
+func TestUInt16Thing(t *testing.T) {
+	var original uint16
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func BenchmarkUInt16Thing(b *testing.B) {
+	var result Thing
+	var t uint16 = 1
+	f := func(g Thing) Thing { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -198,6 +368,25 @@ func BenchmarkUInt32(b *testing.B) {
 	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
 }
 
+func TestUInt32Thing(t *testing.T) {
+	var original uint32
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func BenchmarkUInt32Thing(b *testing.B) {
+	var result Thing
+	var t uint32 = 1
+	f := func(g Thing) Thing { return g }
+	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
+	for i := 0; i < b.N; i++ {
+		result = f(t)
+	}
+	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
+}
+
 func TestUInt64(t *testing.T) {
 	var original uint64
 	result := func(g G) G { return g }(original)
@@ -210,6 +399,25 @@ func BenchmarkUInt64(b *testing.B) {
 	var result G
 	var t uint64 = 1
 	f := func(g G) G { return g }
+	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
+	for i := 0; i < b.N; i++ {
+		result = f(t)
+	}
+	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
+}
+
+func TestUInt64Thing(t *testing.T) {
+	var original uint64
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func BenchmarkUInt64Thing(b *testing.B) {
+	var result Thing
+	var t uint64 = 1
+	f := func(g Thing) Thing { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -233,9 +441,33 @@ func TestFloat64(t *testing.T) {
 	}
 }
 
+func TestFloat32Thing(t *testing.T) {
+	var original float32
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func TestFloat64Thing(t *testing.T) {
+	var original float64
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
 func TestComplex64(t *testing.T) {
 	var original complex64
 	result := func(g G) G { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func TestComplex64Thing(t *testing.T) {
+	var original complex64
+	result := func(g Thing) Thing { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -249,9 +481,25 @@ func TestComplex128(t *testing.T) {
 	}
 }
 
+func TestComplex128Thing(t *testing.T) {
+	var original complex128
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
 func TestByte(t *testing.T) {
 	var original byte
 	result := func(g G) G { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func TestByteThing(t *testing.T) {
+	var original byte
+	result := func(g Thing) Thing { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -265,6 +513,14 @@ func TestRune(t *testing.T) {
 	}
 }
 
+func TestRuneThing(t *testing.T) {
+	var original rune
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
 func TestString(t *testing.T) {
 	var original string
 	result := func(g G) G { return g }(original)
@@ -273,9 +529,25 @@ func TestString(t *testing.T) {
 	}
 }
 
+func TestStringThing(t *testing.T) {
+	var original string
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
 func TestArray(t *testing.T) {
 	var original [12]int
 	result := func(g G) G { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func TestArrayThing(t *testing.T) {
+	var original [12]int
+	result := func(g Thing) Thing { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -300,9 +572,36 @@ func BenchmarkSlice(b *testing.B) {
 	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
 }
 
+func TestSliceThing(t *testing.T) {
+	var original []int
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func BenchmarkSliceThing(b *testing.B) {
+	var result Thing
+	var t []int
+	f := func(g Thing) Thing { return g }
+	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
+	for i := 0; i < b.N; i++ {
+		result = f(t)
+	}
+	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
+}
+
 func TestUintpr(t *testing.T) {
 	var original uintptr
 	result := func(g G) G { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func TestUintprThing(t *testing.T) {
+	var original uintptr
+	result := func(g Thing) Thing { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -316,9 +615,25 @@ func TestChan(t *testing.T) {
 	}
 }
 
+func TestChanThing(t *testing.T) {
+	var original chan struct{}
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
 func TestFunc(t *testing.T) {
 	var original func(int, string, complex128)
 	result := func(g G) G { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func TestFuncThing(t *testing.T) {
+	var original func(int, string, complex128)
+	result := func(g Thing) Thing { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -332,9 +647,25 @@ func TestReader(t *testing.T) {
 	}
 }
 
+func TestReaderThing(t *testing.T) {
+	var original io.Reader
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
 func TestWriter(t *testing.T) {
 	var original io.Writer
 	result := func(g G) G { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func TestWriterThing(t *testing.T) {
+	var original io.Writer
+	result := func(g Thing) Thing { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -348,6 +679,14 @@ func TestInterface(t *testing.T) {
 	}
 }
 
+func TestInterfaceThing(t *testing.T) {
+	var original interface{}
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
 func TestStruct(t *testing.T) {
 	var original struct{}
 	result := func(g G) G { return g }(original)
@@ -356,9 +695,25 @@ func TestStruct(t *testing.T) {
 	}
 }
 
+func TestStructThing(t *testing.T) {
+	var original struct{}
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
 func TestG(t *testing.T) {
 	var original G
 	result := func(g G) G { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func TestThing(t *testing.T) {
+	var original Thing
+	result := func(g Thing) Thing { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -383,9 +738,36 @@ func BenchmarkMap(b *testing.B) {
 	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
 }
 
+func TestMapThing(t *testing.T) {
+	var original map[string]int
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func BenchmarkMapThing(b *testing.B) {
+	var result Thing
+	var t map[string]int
+	f := func(g Thing) Thing { return g }
+	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
+	for i := 0; i < b.N; i++ {
+		result = f(t)
+	}
+	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
+}
+
 func TestPointer(t *testing.T) {
 	var original *int
 	result := func(g G) G { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func TestPointerThing(t *testing.T) {
+	var original *int
+	result := func(g Thing) Thing { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -410,9 +792,36 @@ func BenchmarkValue(b *testing.B) {
 	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
 }
 
+func TestValueThing(t *testing.T) {
+	var original reflect.Value
+	result := func(g Thing) Thing { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func BenchmarkValueThing(b *testing.B) {
+	var result Thing
+	var t reflect.Value
+	f := func(g Thing) Thing { return g }
+	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
+	for i := 0; i < b.N; i++ {
+		result = f(t)
+	}
+	f(result) // Ensure the compiler does not ruin the purity of the G benchmark
+}
+
 func TestError(t *testing.T) {
 	var original error
 	result := func(g G) G { return g }(original)
+	if !reflect.DeepEqual(original, result) {
+		t.Fail()
+	}
+}
+
+func TestErrorThing(t *testing.T) {
+	var original error
+	result := func(g Thing) Thing { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}


### PR DESCRIPTION
Firstly may I say how incredible this package is, I've needed generics for an age. I've already used this in production code and the productivity and spiritual well being of my team has exploded. They have also started using the gophers Slack channel again without fear of getting into any discussions about generics. 

I've added what I consider a useful enhancement to this package, namely the ```Thing``` interface. Benchmarks indicate it performs as well as ```G``` and the addition is fully tested. Thanks for changing history.

There is one small issue though, I'd like the ```Thing``` interface to be covered by the MIT licence. Could we have two licences in the repo please. Thay way people could copy the ```Thing``` interface so long as they adhered to the MIT terms and the original ```G``` interface would be covered by Apache?