### PR TITLE
Use conventional naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ I couldn't agree more.
 
 That's why I've built package generics.
 
-# Say it with G
-Package generics exposes a single, powerful interface, `G`. With `G`, a golang developer (or gopher, as they like to be called) can confidently and securely rely on the power and flexibility of the built-in `interface{}`, without risking a violation of the core laws and tenets all golang developing gophers are required to adhere to.
+# Say it with T
+Package generics exposes a single, powerful type, `T`. With `T`, a golang developer (or gopher, as they like to be called) can confidently and securely rely on the power and flexibility of the built-in `interface{}`, without risking a violation of the core laws and tenets all golang developing gophers are required to adhere to.
 
-# Getting G
+# Getting T
 
 First, fetch the code using one of the many different officially sanctioned options for retrieving go code. Find each of them documented below for your convenience:
 
@@ -22,7 +22,7 @@ First, fetch the code using one of the many different officially sanctioned opti
 
 `go get github.com/StabbyCutyou/generics`
 
-# Using G
+# Using T
 
 Once you've gotten the code, you can import it like so:
 
@@ -32,8 +32,8 @@ Once you've gotten the code, you can import it like so:
 
 While importing using the dot notation is optional, it is the officially supported method of using package generics, as requiring the developer to type out the word `generics` each time they wish to declare something as being generic is very un-golang. Golang is all about developer productivity, and you can't be productive if you're spending all your time typing out long type declarations.
 
-# G is for Generics
-With `G`, you can take ugly code signatures like this:
+# T is for Type
+With `T`, you can take ugly code signatures like this:
 
 ```go
 func UglyUnIdiomaticQuoteGenericApproachUnquote(poorexcuse ...interface{}) []interface{}
@@ -42,29 +42,29 @@ func UglyUnIdiomaticQuoteGenericApproachUnquote(poorexcuse ...interface{}) []int
 And transform it into the embodiment of meaningful code for which there can be no ambiguity:
 
 ```go
-func Excellence(things ...G) []G
+func Excellence(things ...T) []T
 ```
 
-Clearly, the latter example is far superior, as it screams its intent loud and proud: I am `G`, and I am generic!
+Clearly, the latter example is far superior, as it screams its intent loud and proud: I am `T`, and I am ~generic~ type-safe!
 
 # Backwards Compatibility
-`G` meets the standard of golang by matching its stance on backwards compatibility. Until a 2.0 release of generics, which may never happen, `G` will always be 100% backwards compatible with it's initial 1.0 release.
+`T` meets the standard of golang by matching its stance on backwards compatibility. Until a 2.0 release of generics, which may never happen, `T` will always be 100% backwards compatible with it's initial 1.0 release.
 
 # On Law 8
-One possible conflict golang gophers might have is reconciling the use of a small, but well-designed, library such as package generics with Law 8: `A little copying is better than a little dependency.`. So long as all licensing restrictions on the software are adhered to, I have no issue with anyone who wishes to copy, rather than import, the full weight of package generics and its revolutionary `G` type.
+One possible conflict golang gophers might have is reconciling the use of a small, but well-designed, library such as package generics with Law 8: `A little copying is better than a little dependency.`. So long as all licensing restrictions on the software are adhered to, I have no issue with anyone who wishes to copy, rather than import, the full weight of package generics and its revolutionary `T` type.
 
-That said, the idea behind `G` is that it would be compatible across libraries. Until such time as the community-driven `alias` feature being added to an upcoming release of golang is available, packages which implement their own `G` type will find it incompatible with other packages using a different `G`.
+That said, the idea behind `T` is that it would be compatible across libraries. Until such time as the community-driven `alias` feature being added to an upcoming release of golang is available, packages which implement their own `T` type will find it incompatible with other packages using a different `T`.
 
 With that in mind, until the much sought-after `alias` feature is added to golang, I would suggest individuals import the library at this time so as to maintain full compatibility across the golang universe. Until the `alias` syntax arrives, there simply is no clear way to maintain both universal compatibility, and follow Law 8.
 
-It's my sincere hope that golanging gophers everywhere are willing to accept this temporary tradeoff. As soon as `alias` is delivered unto us, I will update this section with official guidelines and best practices on using `alias` with `G`.
+It's my sincere hope that golanging gophers everywhere are willing to accept this temporary tradeoff. As soon as `alias` is delivered unto us, I will update this section with official guidelines and best practices on using `alias` with `T`.
 
 # Afterword
 I hope you enjoy programming with generics as much as I do. The best part about golang is the involvement of the community in shaping the future of the language. Remember:
 
 `interface{} says nothing`
 
-Say it with G, instead!
+Say it with T, instead!
 
 # License
 Apache v2 - See LICENSE

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ func Excellence(things ...T) []T
 
 Clearly, the latter example is far superior, as it screams its intent loud and proud: I am `T`, and I am ~generic~ type-safe!
 
+# Improved Type-Safety
+
+Due to a fact how easy it is to introduce a new type in Go, you can benefit from improved type-safety by introducing your own `T`'s:
+
+```go
+type U T
+
+func SafeExcellence(things ...T) U
+```
+
 # Backwards Compatibility
 `T` meets the standard of golang by matching its stance on backwards compatibility. Until a 2.0 release of generics, which may never happen, `T` will always be 100% backwards compatible with it's initial 1.0 release.
 

--- a/t.go
+++ b/t.go
@@ -2,5 +2,5 @@
 // while adhering to the holy laws of golang.
 package generics
 
-// G is an interface under which all possible types apply
-type G interface{}
+// T is an interface under which all possible types apply
+type T interface{}

--- a/t_test.go
+++ b/t_test.go
@@ -11,15 +11,15 @@ import (
 
 func TestBool(t *testing.T) {
 	var original bool
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
 }
 
 func BenchmarkBool(b *testing.B) {
-	var result G
-	f := func(g G) G { return g }
+	var result T
+	f := func(g T) T { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(true)
@@ -29,16 +29,16 @@ func BenchmarkBool(b *testing.B) {
 
 func TestInt(t *testing.T) {
 	var original int
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
 }
 
 func BenchmarkInt(b *testing.B) {
-	var result G
+	var result T
 	var t int = 1
-	f := func(g G) G { return g }
+	f := func(g T) T { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -48,16 +48,16 @@ func BenchmarkInt(b *testing.B) {
 
 func TestInt8(t *testing.T) {
 	var original int8
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
 }
 
 func BenchmarkInt8(b *testing.B) {
-	var result G
+	var result T
 	var t int8 = 1
-	f := func(g G) G { return g }
+	f := func(g T) T { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -67,16 +67,16 @@ func BenchmarkInt8(b *testing.B) {
 
 func TestInt16(t *testing.T) {
 	var original int16
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
 }
 
 func BenchmarkInt16(b *testing.B) {
-	var result G
+	var result T
 	var t int16 = 1
-	f := func(g G) G { return g }
+	f := func(g T) T { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -86,16 +86,16 @@ func BenchmarkInt16(b *testing.B) {
 
 func TestInt32(t *testing.T) {
 	var original int32
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
 }
 
 func BenchmarkInt32(b *testing.B) {
-	var result G
+	var result T
 	var t int32 = 1
-	f := func(g G) G { return g }
+	f := func(g T) T { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -105,16 +105,16 @@ func BenchmarkInt32(b *testing.B) {
 
 func TestInt64(t *testing.T) {
 	var original int64
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
 }
 
 func BenchmarkInt64(b *testing.B) {
-	var result G
+	var result T
 	var t int64 = 1
-	f := func(g G) G { return g }
+	f := func(g T) T { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -124,16 +124,16 @@ func BenchmarkInt64(b *testing.B) {
 
 func TestUInt(t *testing.T) {
 	var original uint
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
 }
 
 func BenchmarkUInt(b *testing.B) {
-	var result G
+	var result T
 	var t uint = 1
-	f := func(g G) G { return g }
+	f := func(g T) T { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -143,16 +143,16 @@ func BenchmarkUInt(b *testing.B) {
 
 func TestUInt8(t *testing.T) {
 	var original uint8
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
 }
 
 func BenchmarkUInt8(b *testing.B) {
-	var result G
+	var result T
 	var t uint8 = 1
-	f := func(g G) G { return g }
+	f := func(g T) T { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -162,16 +162,16 @@ func BenchmarkUInt8(b *testing.B) {
 
 func TestUInt16(t *testing.T) {
 	var original uint16
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
 }
 
 func BenchmarkUInt16(b *testing.B) {
-	var result G
+	var result T
 	var t uint16 = 1
-	f := func(g G) G { return g }
+	f := func(g T) T { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -181,16 +181,16 @@ func BenchmarkUInt16(b *testing.B) {
 
 func TestUInt32(t *testing.T) {
 	var original uint32
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
 }
 
 func BenchmarkUInt32(b *testing.B) {
-	var result G
+	var result T
 	var t uint32 = 1
-	f := func(g G) G { return g }
+	f := func(g T) T { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -200,16 +200,16 @@ func BenchmarkUInt32(b *testing.B) {
 
 func TestUInt64(t *testing.T) {
 	var original uint64
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
 }
 
 func BenchmarkUInt64(b *testing.B) {
-	var result G
+	var result T
 	var t uint64 = 1
-	f := func(g G) G { return g }
+	f := func(g T) T { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -219,7 +219,7 @@ func BenchmarkUInt64(b *testing.B) {
 
 func TestFloat32(t *testing.T) {
 	var original float32
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -227,7 +227,7 @@ func TestFloat32(t *testing.T) {
 
 func TestFloat64(t *testing.T) {
 	var original float64
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -235,7 +235,7 @@ func TestFloat64(t *testing.T) {
 
 func TestComplex64(t *testing.T) {
 	var original complex64
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -243,7 +243,7 @@ func TestComplex64(t *testing.T) {
 
 func TestComplex128(t *testing.T) {
 	var original complex128
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -251,7 +251,7 @@ func TestComplex128(t *testing.T) {
 
 func TestByte(t *testing.T) {
 	var original byte
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -259,7 +259,7 @@ func TestByte(t *testing.T) {
 
 func TestRune(t *testing.T) {
 	var original rune
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -267,7 +267,7 @@ func TestRune(t *testing.T) {
 
 func TestString(t *testing.T) {
 	var original string
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -275,7 +275,7 @@ func TestString(t *testing.T) {
 
 func TestArray(t *testing.T) {
 	var original [12]int
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -283,16 +283,16 @@ func TestArray(t *testing.T) {
 
 func TestSlice(t *testing.T) {
 	var original []int
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
 }
 
 func BenchmarkSlice(b *testing.B) {
-	var result G
+	var result T
 	var t []int
-	f := func(g G) G { return g }
+	f := func(g T) T { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -302,7 +302,7 @@ func BenchmarkSlice(b *testing.B) {
 
 func TestUintpr(t *testing.T) {
 	var original uintptr
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -310,7 +310,7 @@ func TestUintpr(t *testing.T) {
 
 func TestChan(t *testing.T) {
 	var original chan struct{}
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -318,7 +318,7 @@ func TestChan(t *testing.T) {
 
 func TestFunc(t *testing.T) {
 	var original func(int, string, complex128)
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -326,7 +326,7 @@ func TestFunc(t *testing.T) {
 
 func TestReader(t *testing.T) {
 	var original io.Reader
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -334,7 +334,7 @@ func TestReader(t *testing.T) {
 
 func TestWriter(t *testing.T) {
 	var original io.Writer
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -342,7 +342,7 @@ func TestWriter(t *testing.T) {
 
 func TestInterface(t *testing.T) {
 	var original interface{}
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -350,15 +350,15 @@ func TestInterface(t *testing.T) {
 
 func TestStruct(t *testing.T) {
 	var original struct{}
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
 }
 
 func TestG(t *testing.T) {
-	var original G
-	result := func(g G) G { return g }(original)
+	var original T
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -366,16 +366,16 @@ func TestG(t *testing.T) {
 
 func TestMap(t *testing.T) {
 	var original map[string]int
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
 }
 
 func BenchmarkMap(b *testing.B) {
-	var result G
+	var result T
 	var t map[string]int
-	f := func(g G) G { return g }
+	f := func(g T) T { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -385,7 +385,7 @@ func BenchmarkMap(b *testing.B) {
 
 func TestPointer(t *testing.T) {
 	var original *int
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
@@ -393,16 +393,16 @@ func TestPointer(t *testing.T) {
 
 func TestValue(t *testing.T) {
 	var original reflect.Value
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}
 }
 
 func BenchmarkValue(b *testing.B) {
-	var result G
+	var result T
 	var t reflect.Value
-	f := func(g G) G { return g }
+	f := func(g T) T { return g }
 	b.ResetTimer() // Ensure the preliminary work is not factored into the benchmark
 	for i := 0; i < b.N; i++ {
 		result = f(t)
@@ -412,7 +412,7 @@ func BenchmarkValue(b *testing.B) {
 
 func TestError(t *testing.T) {
 	var original error
-	result := func(g G) G { return g }(original)
+	result := func(g T) T { return g }(original)
 	if !reflect.DeepEqual(original, result) {
 		t.Fail()
 	}


### PR DESCRIPTION
Hello,

I deeply appreciate your efforts to bring the feature that exists in all modern languages these days to Go, however I was concerned about the name you've chosen. I believe the use of more conventional names like `T`, `U` or even `V` would be helpful for newcomers with background in such languages as Java or C++, as in this case the code looks more similar to what they are probably used to.

Again, appreciate your time and efforts.